### PR TITLE
Improve tests by including capability lookups and using unique idempotency keys

### DIFF
--- a/v2/api-validator/package-lock.json
+++ b/v2/api-validator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fireblocks-netlink-v2-api-validator",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fireblocks-netlink-v2-api-validator",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -52,7 +52,7 @@ describe('Test request bodies missing one required property', () => {
             const badBody = _.cloneDeep(goodBody);
             deleteDeepProperty(badBody, propertyPath);
 
-            if (badBody?.['idempotencyKey']) {
+            if (Object.prototype.hasOwnProperty.call(badBody, 'idempotencyKey')) {
               badBody['idempotencyKey'] = randomUUID();
             }
 

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -2,30 +2,28 @@ import _ from 'lodash';
 import { JsonValue } from 'type-fest';
 import ApiClient from '../../src/client';
 import { JSONSchemaFaker, Schema } from 'json-schema-faker';
-import {EndpointSchema, getAllEndpointSchemas} from '../../src/schemas';
+import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
 import { deleteDeepProperty, getPropertyPaths } from '../property-extraction';
-import {ApiComponents, ApiError, BadRequestError, RequestPart} from '../../src/client/generated';
-import {AssetsDirectory} from "../utils/assets-directory";
-import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
-import {getRequestBody} from "../../src/client/generated/core/request";
-import {randomUUID} from "crypto";
+import { ApiComponents, ApiError, BadRequestError, RequestPart } from '../../src/client/generated';
+import { getCapableAccountId, hasCapability } from '../utils/capable-accounts';
+import { randomUUID } from 'crypto';
 
 JSONSchemaFaker.option('requiredOnly', true);
 
 describe('Test request bodies missing one required property', () => {
   const client = new ApiClient();
-  const postEndpoints = getAllEndpointSchemas().filter(
-      (op) => {
-        const [capability] = op.schema.tags
-        return op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
-      }
-  );
+  const postEndpoints = getAllEndpointSchemas().filter((op) => {
+    const [capability] = op.schema.tags;
+    return (
+      op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
+    );
+  });
 
   let accountId: string;
 
   describe.each(postEndpoints)('$method $url', ({ operationId, url, schema }: EndpointSchema) => {
-    const [component] = schema.tags
-    accountId = getCapableAccountId(component as keyof ApiComponents)
+    const [component] = schema.tags;
+    accountId = getCapableAccountId(component as keyof ApiComponents);
 
     // Test multiple times due to the randomness of the generated payloads
     describe.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])('Attempt %d', () => {

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -2,19 +2,31 @@ import _ from 'lodash';
 import { JsonValue } from 'type-fest';
 import ApiClient from '../../src/client';
 import { JSONSchemaFaker, Schema } from 'json-schema-faker';
-import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
+import {EndpointSchema, getAllEndpointSchemas} from '../../src/schemas';
 import { deleteDeepProperty, getPropertyPaths } from '../property-extraction';
-import { ApiError, BadRequestError, RequestPart } from '../../src/client/generated';
+import {ApiComponents, ApiError, BadRequestError, RequestPart} from '../../src/client/generated';
+import {AssetsDirectory} from "../utils/assets-directory";
+import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
+import {getRequestBody} from "../../src/client/generated/core/request";
+import {randomUUID} from "crypto";
 
 JSONSchemaFaker.option('requiredOnly', true);
 
 describe('Test request bodies missing one required property', () => {
   const client = new ApiClient();
   const postEndpoints = getAllEndpointSchemas().filter(
-    (op) => op.method === 'POST' && op.schema.body
+      (op) => {
+        const [capability] = op.schema.tags
+        return op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
+      }
   );
 
+  let accountId: string;
+
   describe.each(postEndpoints)('$method $url', ({ operationId, url, schema }: EndpointSchema) => {
+    const [component] = schema.tags
+    accountId = getCapableAccountId(component as keyof ApiComponents)
+
     // Test multiple times due to the randomness of the generated payloads
     describe.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])('Attempt %d', () => {
       const goodBody = JSONSchemaFaker.generate(schema.body as Schema);
@@ -24,7 +36,7 @@ describe('Test request bodies missing one required property', () => {
         const operationFunction = client[schema.tags[0]]?.[operationId].bind(client);
 
         try {
-          await operationFunction({ requestBody });
+          await operationFunction({ requestBody, accountId });
         } catch (err) {
           if (err instanceof ApiError) {
             return err;
@@ -41,6 +53,11 @@ describe('Test request bodies missing one required property', () => {
           beforeAll(async () => {
             const badBody = _.cloneDeep(goodBody);
             deleteDeepProperty(badBody, propertyPath);
+
+            if (badBody?.['idempotencyKey']) {
+              badBody['idempotencyKey'] = randomUUID();
+            }
+
             apiError = await sendRequest(badBody);
           });
 

--- a/v2/api-validator/tests/server-tests/not-found.test.ts
+++ b/v2/api-validator/tests/server-tests/not-found.test.ts
@@ -2,9 +2,9 @@ import { randomUUID } from 'crypto';
 import { JsonValue } from 'type-fest';
 import { fakeObject } from '../faker';
 import Client from '../../src/client';
-import {ApiComponents, ApiError, GeneralError} from '../../src/client/generated';
+import { ApiComponents, ApiError, GeneralError } from '../../src/client/generated';
 import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
-import {hasCapability} from "../utils/capable-accounts";
+import { hasCapability } from '../utils/capable-accounts';
 
 describe('Not Found tests', () => {
   describe.each(getParamEndpoints())('$method $url', ({ method, operationId, schema }) => {
@@ -61,7 +61,7 @@ describe('Not Found tests', () => {
 
 function getParamEndpoints(): EndpointSchema[] {
   return getAllEndpointSchemas().filter((endpoint) => {
-    const [capability] = endpoint.schema.tags
-    return !!endpoint.schema.params && hasCapability(capability as keyof ApiComponents)
+    const [capability] = endpoint.schema.tags;
+    return !!endpoint.schema.params && hasCapability(capability as keyof ApiComponents);
   });
 }

--- a/v2/api-validator/tests/server-tests/not-found.test.ts
+++ b/v2/api-validator/tests/server-tests/not-found.test.ts
@@ -28,7 +28,10 @@ describe('Not Found tests', () => {
       if (method === 'POST') {
         requestBody = fakeObject(schema.body);
 
-        if (requestBody?.['idempotencyKey']) {
+        if (
+          requestBody !== undefined &&
+          Object.prototype.hasOwnProperty.call(requestBody, 'idempotencyKey')
+        ) {
           requestBody['idempotencyKey'] = randomUUID();
         }
       }

--- a/v2/api-validator/tests/server-tests/not-found.test.ts
+++ b/v2/api-validator/tests/server-tests/not-found.test.ts
@@ -2,8 +2,9 @@ import { randomUUID } from 'crypto';
 import { JsonValue } from 'type-fest';
 import { fakeObject } from '../faker';
 import Client from '../../src/client';
-import { ApiError, GeneralError } from '../../src/client/generated';
+import {ApiComponents, ApiError, GeneralError} from '../../src/client/generated';
 import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
+import {hasCapability} from "../utils/capable-accounts";
 
 describe('Not Found tests', () => {
   describe.each(getParamEndpoints())('$method $url', ({ method, operationId, schema }) => {
@@ -26,6 +27,10 @@ describe('Not Found tests', () => {
       let requestBody: JsonValue | undefined = undefined;
       if (method === 'POST') {
         requestBody = fakeObject(schema.body);
+
+        if (requestBody?.['idempotencyKey']) {
+          requestBody['idempotencyKey'] = randomUUID();
+        }
       }
 
       try {
@@ -55,5 +60,8 @@ describe('Not Found tests', () => {
 });
 
 function getParamEndpoints(): EndpointSchema[] {
-  return getAllEndpointSchemas().filter((endpoint) => !!endpoint.schema.params);
+  return getAllEndpointSchemas().filter((endpoint) => {
+    const [capability] = endpoint.schema.tags
+    return !!endpoint.schema.params && hasCapability(capability as keyof ApiComponents)
+  });
 }

--- a/v2/api-validator/tests/server-tests/pagination-params.test.ts
+++ b/v2/api-validator/tests/server-tests/pagination-params.test.ts
@@ -10,7 +10,7 @@ import {
   PaginationStartingAfter,
   RequestPart,
 } from '../../src/client/generated';
-import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
+import { getCapableAccountId, hasCapability } from '../utils/capable-accounts';
 
 type PaginationParams = {
   limit?: PaginationLimit;
@@ -33,7 +33,7 @@ describe('Pagination params tests', () => {
 
       try {
         if (params !== undefined) {
-          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents)
+          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
         }
       } catch (e) {
         // no capable account, use faked account

--- a/v2/api-validator/tests/server-tests/pagination-params.test.ts
+++ b/v2/api-validator/tests/server-tests/pagination-params.test.ts
@@ -31,12 +31,8 @@ describe('Pagination params tests', () => {
       const querystring = fakeObject(schema.querystring);
       const params = fakeObject(schema.params);
 
-      try {
-        if (params !== undefined) {
-          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
-        }
-      } catch (e) {
-        // no capable account, use faked account
+      if (params !== undefined && Object.prototype.hasOwnProperty.call(params, 'accountId')) {
+        params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
       }
 
       try {

--- a/v2/api-validator/tests/server-tests/security-headers.test.ts
+++ b/v2/api-validator/tests/server-tests/security-headers.test.ts
@@ -5,11 +5,13 @@ import { AxiosRequestConfig } from 'axios';
 import { getAllEndpointSchemas } from '../../src/schemas';
 import { createSecurityHeaders, SecurityHeaders } from '../../src/client/SecureClient';
 import {
+  ApiComponents,
   ApiError,
   BadRequestError,
   RequestPart,
   UnauthorizedError,
 } from '../../src/client/generated';
+import {hasCapability} from "../utils/capable-accounts";
 
 type HeadersGenerator = (options: AxiosRequestConfig) => SecurityHeaders;
 
@@ -34,7 +36,10 @@ function headersWithoutTimestamp(options: AxiosRequestConfig): SecurityHeaders {
 }
 
 describe('Security header tests', () => {
-  const supportedOpenApiEndpoints = getAllEndpointSchemas();
+  const supportedOpenApiEndpoints = getAllEndpointSchemas().filter((op) => {
+    const [capability] = op.schema.tags;
+    return hasCapability(capability as keyof ApiComponents);
+  });
 
   describe.each(supportedOpenApiEndpoints)('$method $url', ({ method, operationId, schema }) => {
     const sendRequest = async (headersGenerator: HeadersGenerator) => {

--- a/v2/openapi/fb-provider-liquidity-api.yaml
+++ b/v2/openapi/fb-provider-liquidity-api.yaml
@@ -261,7 +261,6 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         fromAsset:
           $ref: '#/x-schemas/AssetReference'
         fromAmount:

--- a/v2/openapi/fb-unified-openapi.yaml
+++ b/v2/openapi/fb-unified-openapi.yaml
@@ -2529,7 +2529,6 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         fromAsset:
           $ref: '#/components/schemas/AssetReference'
         fromAmount:


### PR DESCRIPTION
Various tests were not checking the capability of the API before running tests, this resulted in several failures were endpoints were not supported.

In addition to that, the idempotency key used for testing was not always unique between requests. This resulted in failures when a success was expected.